### PR TITLE
fix: handle missing navigator in getRelativeTimeString

### DIFF
--- a/app/utils/get-relative-time.ts
+++ b/app/utils/get-relative-time.ts
@@ -5,7 +5,7 @@
  */
 export function getRelativeTimeString(
   date: Date | number,
-  lang = navigator.language
+  lang?: string
 ): string {
   // Allow dates or times to be passed
   const timeMs = typeof date === "number" ? date : date.getTime();
@@ -45,6 +45,8 @@ export function getRelativeTimeString(
   const divisor = unitIndex ? cutoffs[unitIndex - 1] : 1;
 
   // Intl.RelativeTimeFormat do its magic
-  const rtf = new Intl.RelativeTimeFormat(lang, { numeric: "auto" });
+  const language =
+    lang ?? (typeof navigator === "undefined" ? "en-US" : navigator.language);
+  const rtf = new Intl.RelativeTimeFormat(language, { numeric: "auto" });
   return rtf.format(Math.floor(deltaSeconds / divisor), units[unitIndex]);
 }


### PR DESCRIPTION
## Summary
- avoid `navigator` reference errors in `getRelativeTimeString`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689363a44ea4832486f7be2879cf637c