### PR TITLE
fix: handle missing navigator and recipe generation error

### DIFF
--- a/app/api/route/route.ts
+++ b/app/api/route/route.ts
@@ -29,8 +29,10 @@ export async function POST(request: Request) {
     Retorne apenas o preparo e o título da receita, incluindo emojis se necessário.
   `;
 
-    const result = await model.generateContent(prompt);
-    const response = await result.response.text();
+    // The SDK expects the prompt as an array of strings or parts.
+    // Passing a plain string can result in a 500 from the server.
+    const result = await model.generateContent([prompt]);
+    const response = result.response.text();
 
     const [recipeTitleAndSteps, tipsText] = response.split('Dicas:');
     const [recipeTitle, ...stepsArray] = recipeTitleAndSteps.split('\n').filter(Boolean);

--- a/app/utils/get-relative-time.ts
+++ b/app/utils/get-relative-time.ts
@@ -5,7 +5,7 @@
  */
 export function getRelativeTimeString(
   date: Date | number,
-  lang = navigator.language
+  lang?: string
 ): string {
   // Allow dates or times to be passed
   const timeMs = typeof date === "number" ? date : date.getTime();
@@ -45,6 +45,8 @@ export function getRelativeTimeString(
   const divisor = unitIndex ? cutoffs[unitIndex - 1] : 1;
 
   // Intl.RelativeTimeFormat do its magic
-  const rtf = new Intl.RelativeTimeFormat(lang, { numeric: "auto" });
+  const language =
+    lang ?? (typeof navigator === "undefined" ? "en-US" : navigator.language);
+  const rtf = new Intl.RelativeTimeFormat(language, { numeric: "auto" });
   return rtf.format(Math.floor(deltaSeconds / divisor), units[unitIndex]);
 }


### PR DESCRIPTION
## Summary
- avoid `navigator` reference errors in `getRelativeTimeString`
- send prompt to Gemini as an array to prevent recipe-generation 500s

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689363a44ea4832486f7be2879cf637c