### PR TITLE
Handle API error body

### DIFF
--- a/app/components/pages/generate/form-generate/index.tsx
+++ b/app/components/pages/generate/form-generate/index.tsx
@@ -38,7 +38,8 @@ export const FormGenerate = () => {
       });
   
       if (!response.ok) {
-        throw new Error(`Erro na solicitação: ${response.statusText}`);
+        const { error } = await response.json();
+        throw new Error(`Erro na solicitação: ${error || response.statusText}`);
       }
   
       const text = await response.text();


### PR DESCRIPTION
## Summary
- include backend error message in thrown exception when recipe generation fails
- surface backend error message in user-facing modal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68936c8f49f48324b33665cdfbaf28ec