### PR TITLE
feat: improve response parsing

### DIFF
--- a/app/components/pages/generate/form-generate/index.tsx
+++ b/app/components/pages/generate/form-generate/index.tsx
@@ -37,16 +37,19 @@ export const FormGenerate = () => {
         }),
       });
   
-      if (!response.ok) {
-        const { error } = await response.json();
-        throw new Error(`Erro na solicitação: ${error || response.statusText}`);
+      const contentType = response.headers.get('content-type') || '';
+      const data = contentType.includes('application/json')
+        ? await response.json().catch(() => null)
+        : await response.text().catch(() => null);
+
+      if (!response.ok || !data) {
+        setErrorMessage('Serviço temporariamente indisponível');
+        setShowErrorModal(true);
+        return;
       }
-  
-      const text = await response.text();
-      console.log('Resposta do fetch:', text);
-  
-      const result = JSON.parse(text);
-  
+
+      const result = typeof data === 'string' ? { instructions: data } : data;
+
       if (result.instructions) {
         setResponse(result.instructions);
         console.log('Instruções recebidas:', result.instructions);


### PR DESCRIPTION
## Summary
- handle API responses by checking content type and parsing JSON or text accordingly
- show a friendly error message when the request fails or returns no data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`, `Indie Flower`)*

------
https://chatgpt.com/codex/tasks/task_e_689371e463f08324acd994fb39283342