### PR TITLE
feat: store recent recipes

### DIFF
--- a/app/api/route/__tests__/route.test.ts
+++ b/app/api/route/__tests__/route.test.ts
@@ -42,6 +42,7 @@ describe('POST /api/route', () => {
     expect(mockGenerateContent).toHaveBeenCalled();
     expect(json.instructions).toContain('Recipe Title');
     expect(json.instructions).toContain('Step 1');
+    expect(json.title).toBe('Recipe Title');
   });
 
   it('returns fallback instructions when generation fails', async () => {
@@ -58,6 +59,7 @@ describe('POST /api/route', () => {
 
     expect(mockGenerateContent).toHaveBeenCalled();
     expect(json.instructions).toContain('Receita simples de Breakfast');
+    expect(json.title).toBe('Receita simples de Breakfast');
   });
 
   it('returns fallback instructions when API key is missing', async () => {
@@ -73,5 +75,6 @@ describe('POST /api/route', () => {
 
     expect(mockGenerateContent).not.toHaveBeenCalled();
     expect(json.instructions).toContain('Receita simples de Breakfast');
+    expect(json.title).toBe('Receita simples de Breakfast');
   });
 });

--- a/app/api/route/route.ts
+++ b/app/api/route/route.ts
@@ -66,7 +66,11 @@ export async function POST(request: Request) {
         selectedUtensils,
         time,
       });
-      return NextResponse.json({ instructions: fallback }, { status: 200 });
+      const fallbackTitle = `Receita simples de ${MealType}`;
+      return NextResponse.json(
+        { title: fallbackTitle, instructions: fallback },
+        { status: 200 }
+      );
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
@@ -136,7 +140,10 @@ export async function POST(request: Request) {
         </div>
       `;
 
-      return NextResponse.json({ instructions: htmlContent });
+      return NextResponse.json({
+        title: formattedTitle,
+        instructions: htmlContent,
+      });
     } catch (error) {
       console.error('Falha ao gerar conteúdo com Gemini:', error);
       const fallback = buildFallback({
@@ -146,7 +153,11 @@ export async function POST(request: Request) {
         selectedUtensils,
         time,
       });
-      return NextResponse.json({ instructions: fallback }, { status: 200 });
+      const fallbackTitle = `Receita simples de ${MealType}`;
+      return NextResponse.json(
+        { title: fallbackTitle, instructions: fallback },
+        { status: 200 }
+      );
     }
   } catch (error: unknown) {
     console.error('Erro ao processar a solicitação:', error);

--- a/app/components/pages/generate/form-generate/index.tsx
+++ b/app/components/pages/generate/form-generate/index.tsx
@@ -48,10 +48,17 @@ export const FormGenerate = () => {
         return;
       }
 
-      const result = typeof data === 'string' ? { instructions: data } : data;
+      const result =
+        typeof data === 'string' ? { instructions: data, title: '' } : data;
 
       if (result.instructions) {
         setResponse(result.instructions);
+        if (result.title) {
+          const stored = localStorage.getItem('recent-recipes');
+          const recent = stored ? JSON.parse(stored) : [];
+          recent.push({ title: result.title, createdAt: Date.now() });
+          localStorage.setItem('recent-recipes', JSON.stringify(recent));
+        }
         console.log('Instruções recebidas:', result.instructions);
       } else {
         setErrorMessage("Erro ao encontrar uma resposta.");

--- a/app/components/pages/home/last-recipes/index.tsx
+++ b/app/components/pages/home/last-recipes/index.tsx
@@ -1,27 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { SectionTitle } from "@/app/components/section-title";
-import { CookingPot, ForkKnife } from "@phosphor-icons/react";
+import { CookingPot } from "@phosphor-icons/react";
 import { Recipe } from "./recipe";
 
+type StoredRecipe = {
+  title: string;
+  createdAt: number;
+};
+
 export const LastRecipes = () => {
-  return ( 
-  
+  const [recipes, setRecipes] = useState<StoredRecipe[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("recent-recipes");
+    if (stored) {
+      const parsed: StoredRecipe[] = JSON.parse(stored);
+      parsed.sort((a, b) => b.createdAt - a.createdAt);
+      setRecipes(parsed);
+    }
+  }, []);
+
+  return (
     <section className="container py-16">
       <CookingPot />
       <SectionTitle title="Receitas recentes" subtitle="últimas receitas" />
       <div className="grid grid-cols-[repeat(auto-fit,minmax(264px,1fr))] gap-3">
-        {Array.from({ length: 4 }).map((_, index) => (
+        {recipes.map((recipe, index) => (
           <Recipe
             key={index}
             recipe={{
               icon: <CookingPot />,
-              name: 'Macarrão com Sasicha',
-              image: '',
-              startDate: '2024/08/26',
+              name: recipe.title,
+              image: "",
+              startDate: new Date(recipe.createdAt).toISOString(),
             }}
           />
         ))}
       </div>
     </section>
-
   );
 };


### PR DESCRIPTION
## Summary
- include recipe title in API response
- save recent recipe titles to localStorage
- show recent recipes list from localStorage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689391dfd21c832485a4dd36e12d800a