### PR TITLE
chore: remove unused Slider import

### DIFF
--- a/app/components/pages/home/last-recipes/recipe.tsx
+++ b/app/components/pages/home/last-recipes/recipe.tsx
@@ -3,7 +3,6 @@ import { getRelativeTimeString } from "@/app/utils/get-relative-time";
 import Image from "next/image";
 import { ReactNode } from "react";
 import { ForkKnife } from "@phosphor-icons/react";
-import Slider from "react-slick"
 
 type RecipeProps = {
   recipe: {


### PR DESCRIPTION
## Summary
- remove unused `react-slick` import from recipe component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893950c620483249a26b1928a8cf734