### PR TITLE
feat: enable recipe editing in modal

### DIFF
--- a/app/components/pages/generate/form-generate/index.tsx
+++ b/app/components/pages/generate/form-generate/index.tsx
@@ -8,11 +8,17 @@ type RecipeModalProps = {
   isOpen: boolean;
   content: string | null;
   onClose: () => void;
-  onEdit: () => void;
+  onSave: (updatedContent: string) => void;
 };
 
-const RecipeModal = ({ isOpen, content, onClose, onEdit }: RecipeModalProps) => {
+const RecipeModal = ({ isOpen, content, onClose, onSave }: RecipeModalProps) => {
   const closeRef = useRef<HTMLButtonElement>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editableContent, setEditableContent] = useState(content || "");
+
+  useEffect(() => {
+    setEditableContent(content || "");
+  }, [content]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -45,13 +51,43 @@ const RecipeModal = ({ isOpen, content, onClose, onEdit }: RecipeModalProps) => 
         >
           X
         </button>
-        <div
-          className="text-black"
-          dangerouslySetInnerHTML={{ __html: content }}
-        />
-        <Button className="mt-4" onClick={onEdit}>
-          Editar
-        </Button>
+        {isEditing ? (
+          <>
+            <textarea
+              className="w-full h-[300px] text-black border border-gray-300 rounded"
+              value={editableContent}
+              onChange={(e) => setEditableContent(e.target.value)}
+            />
+            <div className="flex gap-2 mt-4">
+              <Button
+                onClick={() => {
+                  onSave(editableContent);
+                  setIsEditing(false);
+                }}
+              >
+                Salvar
+              </Button>
+              <Button
+                onClick={() => {
+                  setEditableContent(content || "");
+                  setIsEditing(false);
+                }}
+              >
+                Cancelar
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div
+              className="text-black"
+              dangerouslySetInnerHTML={{ __html: content }}
+            />
+            <Button className="mt-4" onClick={() => setIsEditing(true)}>
+              Editar
+            </Button>
+          </>
+        )}
       </div>
     </div>
   );
@@ -77,9 +113,8 @@ export const FormGenerate = () => {
 
   const formRef = useRef<HTMLElement | null>(null);
 
-  const handleEditRecipe = () => {
-    setShowRecipeModal(false);
-    formRef.current?.scrollIntoView({ behavior: 'smooth' });
+  const handleSaveRecipe = (edited: string) => {
+    setResponse(edited);
   };
 
   const handleGenerateRecipe = async () => {
@@ -281,7 +316,7 @@ export const FormGenerate = () => {
         isOpen={showRecipeModal}
         content={response}
         onClose={() => setShowRecipeModal(false)}
-        onEdit={handleEditRecipe}
+        onSave={handleSaveRecipe}
       />
 
     </section>


### PR DESCRIPTION
## Summary
- allow editing recipes inside modal
- persist changes via onSave handler in FormGenerate

## Testing
- `npm test --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6893ae7bd3e4832491019f929eb313a0