### PR TITLE
Use Button for recent recipe items and truncate titles

### DIFF
--- a/app/components/pages/generate/form-generate/index.tsx
+++ b/app/components/pages/generate/form-generate/index.tsx
@@ -329,15 +329,15 @@ export const FormGenerate = () => {
       <ul className="flex flex-col gap-2">
         {recentRecipes.map((recipe, index) => (
           <li key={index}>
-            <button
-              className="text-left w-full hover:underline"
+            <Button
+              className="w-full text-left hover:underline overflow-hidden text-ellipsis whitespace-nowrap !justify-start"
               onClick={() => {
                 setResponse(recipe.instructions);
                 setShowRecipeModal(true);
               }}
             >
               {recipe.title}
-            </button>
+            </Button>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- use shared `Button` component for recent recipe links
- prevent long recipe titles from overflowing with Tailwind truncation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893b740befc83248c68d465fcbf11be