### PR TITLE
Add PDF download option to RecipeModal

### DIFF
--- a/app/components/pages/generate/form-generate/index.tsx
+++ b/app/components/pages/generate/form-generate/index.tsx
@@ -3,6 +3,8 @@ import { Basket, Check, ChefHat, ForkKnife } from "@phosphor-icons/react/dist/ss
 import  {ChefLevel, IngredientsItem, UtensilsItem } from "@/app/components/array-select";
 import { Additional, MealType } from "@/app/components/array-select";
 import { Button } from "@/app/components/button";
+import jsPDF from "jspdf";
+import html2canvas from "html2canvas";
 
 type StoredRecipe = {
   title: string;
@@ -19,6 +21,18 @@ type RecipeModalProps = {
 
 const RecipeModal = ({ isOpen, content, onClose, onEdit }: RecipeModalProps) => {
   const closeRef = useRef<HTMLButtonElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const handleDownloadPdf = async () => {
+    if (!contentRef.current) return;
+    const canvas = await html2canvas(contentRef.current);
+    const imgData = canvas.toDataURL("image/png");
+    const pdf = new jsPDF("p", "mm", "a4");
+    const pdfWidth = pdf.internal.pageSize.getWidth();
+    const pdfHeight = (canvas.height * pdfWidth) / canvas.width;
+    pdf.addImage(imgData, "PNG", 0, 0, pdfWidth, pdfHeight);
+    pdf.save("receita.pdf");
+  };
 
   useEffect(() => {
     if (!isOpen) return;
@@ -52,12 +66,14 @@ const RecipeModal = ({ isOpen, content, onClose, onEdit }: RecipeModalProps) => 
           X
         </button>
         <div
+          ref={contentRef}
           className="text-black"
           dangerouslySetInnerHTML={{ __html: content }}
         />
-        <Button className="mt-4" onClick={onEdit}>
-          Editar
-        </Button>
+        <div className="mt-4 flex gap-2">
+          <Button onClick={onEdit}>Editar</Button>
+          <Button onClick={handleDownloadPdf}>Baixar PDF</Button>
+        </div>
       </div>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "date-fns": "2.29.3",
     "dotenv": "^16.4.5",
     "framer-motion": "^10.11.2",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1",
     "multiselect": "^0.9.12",
     "next": "^14.2.21",
     "postcss": "^8.4.41",
@@ -42,8 +44,8 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/react-slick": "^0.23.13",
     "@types/jest": "^29.5.12",
+    "@types/react-slick": "^0.23.13",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1"
   }


### PR DESCRIPTION
## Summary
- add pdf generation dependencies
- export recipe content as downloadable PDF

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893bbace8108324bd0a19f184d3b11c