### PR TITLE
Allow recipes to omit macros

### DIFF
--- a/app/api/route/__tests__/route.test.ts
+++ b/app/api/route/__tests__/route.test.ts
@@ -24,88 +24,97 @@ describe('POST /api/route', () => {
     fat: 20,
   };
 
+  const bodyWithoutMacros = { ...baseBody } as any;
+  delete bodyWithoutMacros.protein;
+  delete bodyWithoutMacros.carbs;
+  delete bodyWithoutMacros.fat;
+
+  const cases = [
+    ['with macros', baseBody, true],
+    ['without macros', bodyWithoutMacros, false],
+  ] as const;
+
   beforeEach(() => {
     mockGenerateContent.mockReset();
   });
 
-  it('returns generated instructions when API succeeds', async () => {
-    process.env.GEMINI_API_KEY = 'test';
-    mockGenerateContent.mockResolvedValue({
-      response: { text: () => 'Recipe Title\nStep 1\nDicas: Tip 1' },
-    });
+  it.each(cases)(
+    'returns generated instructions when API succeeds %s',
+    async (_label, body, hasMacros) => {
+      process.env.GEMINI_API_KEY = 'test';
+      mockGenerateContent.mockResolvedValue({
+        response: { text: () => 'Recipe Title\nStep 1\nDicas: Tip 1' },
+      });
 
-    const request = new Request('http://localhost', {
-      method: 'POST',
-      body: JSON.stringify(baseBody),
-    });
+      const request = new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
 
-    const res = await POST(request);
-    const json = await res.json();
+      const res = await POST(request);
+      const json = await res.json();
 
-    expect(mockGenerateContent).toHaveBeenCalled();
-    expect(json.instructions).toContain('Recipe Title');
-    expect(json.instructions).toContain('Step 1');
-    expect(json.title).toBe('Recipe Title');
-    expect(json.instructions).toContain('Proteína: 30 g');
-  });
+      expect(mockGenerateContent).toHaveBeenCalled();
+      expect(json.instructions).toContain('Recipe Title');
+      expect(json.instructions).toContain('Step 1');
+      expect(json.title).toBe('Recipe Title');
+      if (hasMacros) {
+        expect(json.instructions).toContain('Proteína: 30 g');
+      } else {
+        expect(json.instructions).not.toContain('Macros');
+        expect(json.instructions).not.toContain('Proteína');
+      }
+    }
+  );
 
-  it('returns fallback instructions when generation fails', async () => {
-    process.env.GEMINI_API_KEY = 'test';
-    mockGenerateContent.mockRejectedValue(new Error('fail'));
+  it.each(cases)(
+    'returns fallback instructions when generation fails %s',
+    async (_label, body, hasMacros) => {
+      process.env.GEMINI_API_KEY = 'test';
+      mockGenerateContent.mockRejectedValue(new Error('fail'));
 
-    const request = new Request('http://localhost', {
-      method: 'POST',
-      body: JSON.stringify(baseBody),
-    });
+      const request = new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
 
-    const res = await POST(request);
-    const json = await res.json();
+      const res = await POST(request);
+      const json = await res.json();
 
-    expect(mockGenerateContent).toHaveBeenCalled();
-    expect(json.instructions).toContain('Receita simples de Breakfast');
-    expect(json.instructions).toContain('Proteína: 30 g');
-    expect(json.title).toBe('Receita simples de Breakfast');
-  });
+      expect(mockGenerateContent).toHaveBeenCalled();
+      expect(json.instructions).toContain('Receita simples de Breakfast');
+      if (hasMacros) {
+        expect(json.instructions).toContain('Proteína: 30 g');
+      } else {
+        expect(json.instructions).not.toContain('Macros');
+        expect(json.instructions).not.toContain('Proteína');
+      }
+      expect(json.title).toBe('Receita simples de Breakfast');
+    }
+  );
 
-  it('returns fallback instructions when API key is missing', async () => {
-    delete process.env.GEMINI_API_KEY;
+  it.each(cases)(
+    'returns fallback instructions when API key is missing %s',
+    async (_label, body, hasMacros) => {
+      delete process.env.GEMINI_API_KEY;
 
-    const request = new Request('http://localhost', {
-      method: 'POST',
-      body: JSON.stringify(baseBody),
-    });
+      const request = new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      });
 
-    const res = await POST(request);
-    const json = await res.json();
+      const res = await POST(request);
+      const json = await res.json();
 
-    expect(mockGenerateContent).not.toHaveBeenCalled();
-    expect(json.instructions).toContain('Receita simples de Breakfast');
-    expect(json.instructions).toContain('Proteína: 30 g');
-    expect(json.title).toBe('Receita simples de Breakfast');
-  });
-
-  it('succeeds without macros and omits macros line', async () => {
-    process.env.GEMINI_API_KEY = 'test';
-    mockGenerateContent.mockResolvedValue({
-      response: { text: () => 'Recipe Title\nStep 1\nDicas: Tip 1' },
-    });
-
-    const body = { ...baseBody } as any;
-    delete body.protein;
-    delete body.carbs;
-    delete body.fat;
-
-    const request = new Request('http://localhost', {
-      method: 'POST',
-      body: JSON.stringify(body),
-    });
-
-    const res = await POST(request);
-    const json = await res.json();
-
-    expect(mockGenerateContent).toHaveBeenCalled();
-    expect(json.instructions).toContain('Recipe Title');
-    expect(json.instructions).not.toContain('Macros:');
-    expect(json.instructions).not.toContain('Proteína:');
-  });
+      expect(mockGenerateContent).not.toHaveBeenCalled();
+      expect(json.instructions).toContain('Receita simples de Breakfast');
+      if (hasMacros) {
+        expect(json.instructions).toContain('Proteína: 30 g');
+      } else {
+        expect(json.instructions).not.toContain('Macros');
+        expect(json.instructions).not.toContain('Proteína');
+      }
+      expect(json.title).toBe('Receita simples de Breakfast');
+    }
+  );
 });

--- a/app/api/route/route.ts
+++ b/app/api/route/route.ts
@@ -58,8 +58,9 @@ export async function POST(request: Request) {
       carbs,
       fat,
     } = await request.json();
-    const macrosProvided =
-      protein !== undefined && carbs !== undefined && fat !== undefined;
+    const macrosProvided = [protein, carbs, fat].every(
+      (m) => m !== undefined
+    );
 
     if (
       !ChefLevel ||
@@ -111,7 +112,7 @@ export async function POST(request: Request) {
 
     const macrosLine = macrosProvided
       ? `Macros desejadas (em gramas): Proteína: ${protein} g, Carboidratos: ${carbs} g, Gordura: ${fat} g`
-      : '';
+      : 'Faça a receita sem especificar proteína, carboidratos e gordura.';
 
     const prompt = `
     Crie uma receita com base nas seguintes informações:

--- a/app/components/pages/generate/form-generate/index.tsx
+++ b/app/components/pages/generate/form-generate/index.tsx
@@ -97,15 +97,6 @@ export const FormGenerate = () => {
   };
 
   const handleGenerateRecipe = async () => {
-    if (
-      showDietOptions &&
-      (protein === undefined || carbs === undefined || fat === undefined)
-    ) {
-      setErrorMessage('Preencha todos os campos de dieta');
-      setShowErrorModal(true);
-      return;
-    }
-
     setIsLoading(true);
 
     try {


### PR DESCRIPTION
## Summary
- remove client-side macro validation guard
- make API route accept missing macros and adjust prompt
- cover both macro and no-macro scenarios in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893be7376308324830d324c02319bf6